### PR TITLE
pytest-cov 3.0.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pytest-cov" %}
-{% set version = "2.12.1" %}
-{% set sha256 = "261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7" %}
+{% set version = "3.0.0" %}
+{% set sha256 = "e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ about:
   license_file: LICENSE
   summary: Pytest plugin for measuring coverage
   dev_url: https://github.com/pytest-dev/pytest-cov
+  doc_url: https://pytest-cov.readthedocs.io/en/latest/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,6 +12,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
+  skip: True  # [py<36]
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
   number: 0
@@ -22,16 +23,20 @@ requirements:
     - python
     - setuptools
     - wheel
-
   run:
-    - python
+    - python >=3.6
     - setuptools
     - pytest >=4.6
     - coverage >=5.2.1
     - toml
 
 test:
+  imports:
+    - pytest_cov
+  requires:
+    - pip
   commands:
+    - pip check
     - pytest --traceconfig | grep pytest-cov-{{ version }}
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,6 +35,7 @@ test:
     - pytest_cov
   requires:
     - pip
+    - python <3.10
   commands:
     - pip check
     - pytest --traceconfig | grep pytest-cov-{{ version }}


### PR DESCRIPTION
Update pytest-cov to 3.0.0

Version change: bump version number from 2.12.1 to 3.0.0 (Major version bump!)
Bug Tracker: new open issues https://github.com/pytest-dev/pytest-cov/issues
Upstream license:  License file:  https://github.com/pytest-dev/pytest-cov/blob/master/LICENSE
Upstream Changelog: drop support python 2.7 and 3.5 https://github.com/pytest-dev/pytest-cov/blob/master/CHANGELOG.rst
Upstream setup.py:  https://github.com/pytest-dev/pytest-cov/blob/v3.0.0/setup.py

The package pytest-cov is mentioned inside the packages:
anyio | arrow | ciocheck | conda-build | conda-content-trust | conda-package-handling | conda-package-handling | conda-token | cookiecutter | email-validator | jupyter_client | neon | opt_einsum | portalocker | pytest-astropy | pytest-cov | pytest-filter-subpackage | python-fastjsonschema | python-jose | python-libarchive-c | rasterio | rfc3986 | scikit-build | trustme |

Actions:
1. Skip `py<36`
2. Add test/imports
3. Add `pip check`
4. Add doc_url

Result:
- all-succeeded